### PR TITLE
Handling unexpected constant types

### DIFF
--- a/src/Util/Annotation/DocBlock.php
+++ b/src/Util/Annotation/DocBlock.php
@@ -332,12 +332,11 @@ final class DocBlock
     {
         if (\defined($message) &&
             (\strpos($message, '::') !== false && \substr_count($message, '::') + 1 === 2)) {
-            
             $constant_value = \constant($message);
-            if(\is_string($constant_value)) {
+            if (\is_string($constant_value)) {
                 return $constant_value;
             }
-            
+
             return $message;
         }
 

--- a/src/Util/Annotation/DocBlock.php
+++ b/src/Util/Annotation/DocBlock.php
@@ -332,7 +332,13 @@ final class DocBlock
     {
         if (\defined($message) &&
             (\strpos($message, '::') !== false && \substr_count($message, '::') + 1 === 2)) {
-            return \constant($message);
+            
+            $constant_value = \constant($message);
+            if(\is_string($constant_value)) {
+                return \$constant_value;
+            }
+            
+            return $message;
         }
 
         return $message;

--- a/src/Util/Annotation/DocBlock.php
+++ b/src/Util/Annotation/DocBlock.php
@@ -335,7 +335,7 @@ final class DocBlock
             
             $constant_value = \constant($message);
             if(\is_string($constant_value)) {
-                return \$constant_value;
+                return $constant_value;
             }
             
             return $message;

--- a/src/Util/Annotation/DocBlock.php
+++ b/src/Util/Annotation/DocBlock.php
@@ -333,6 +333,7 @@ final class DocBlock
         if (\defined($message) &&
             (\strpos($message, '::') !== false && \substr_count($message, '::') + 1 === 2)) {
             $constant_value = \constant($message);
+
             if (\is_string($constant_value)) {
                 return $constant_value;
             }

--- a/src/Util/Configuration.php
+++ b/src/Util/Configuration.php
@@ -385,7 +385,8 @@ final class Configuration
 
             if (\defined($value)) {
                 $constant_value = \constant($value);
-                if($constant_value === null || \is_scalar($constant_value)){
+
+                if ($constant_value === null || \is_scalar($constant_value)) {
                     $value = (string) $constant_value;
                 }
             }

--- a/src/Util/Configuration.php
+++ b/src/Util/Configuration.php
@@ -384,7 +384,10 @@ final class Configuration
             $value = $data['value'];
 
             if (\defined($value)) {
-                $value = (string) \constant($value);
+                $constant_value = \constant($value);
+                if($constant_value === null || \is_scalar($constant_value)){
+                    $value = (string) $constant_value;
+                }
             }
 
             \ini_set($name, $value);


### PR DESCRIPTION
As discussed here https://github.com/vimeo/psalm/pull/2612

This PR tries to handle unexpected constant types.

When I looked at the codebase, it appears they don't use the assert() function so I tried to handle it differently.

- For DocBlock.php
There is a string type param(with strict types), which means it failed if $constant_value was not a string. However, the function seems to fallback on $message if there was no constant. I figured I would do the same when constant() return anything but a string
- For Configuration.php
The constant value is used to push to ini_set, which will fail if given anything but a string. The fetching of the constant value is also optional. I checked if the constant value was anything that could be casted to string(scalar or null). If not, I consider the constant as not defined

Those two fixes are subjective, not sure I fixed them the best way possible